### PR TITLE
Fixed missing slashes for namespaced class names

### DIFF
--- a/Classes/MetaDataFileGenerator.php
+++ b/Classes/MetaDataFileGenerator.php
@@ -84,7 +84,7 @@ PHP_STORM_META;
 		foreach ($this->factoryMethods as $factoryMethod) {
 			$metaDataMap .= "		\\$factoryMethod('') => [\n";
 			foreach ($classes as $class) {
-				$metaDataMap .= "			'$class' instanceof \\$class,\n";
+				$metaDataMap .= "			'" . str_replace('\\', '\\\\', $class) . "' instanceof \\$class,\n";
 			}
 			$metaDataMap .= "		],\n";
 		}


### PR DESCRIPTION
Namespaced class names as string uses double slashing so the class names have to be adjusted to point to the right instance class.
