### PR TITLE
[BUGFIX] namespace declaration may be on a line below the second

### DIFF
--- a/Classes/MetaDataFileGenerator.php
+++ b/Classes/MetaDataFileGenerator.php
@@ -211,21 +211,18 @@ PHP_STORM_META;
 	 */
 	protected function getFileNamespace($file) {
 		$fileHandle = fopen($file, "r");
-		$lines = array();
+		$matched = 0;
 		while (!feof($fileHandle)) {
-			$buffer = fgets($fileHandle, 4096);
-			$lines[] = $buffer;
-
-			if (count($lines) == 2) {
+			$line = fgets($fileHandle, 4096);
+			$matches = NULL;
+			$matched = preg_match('/^namespace[ \t]+(.*);$/', $line, $matches);
+			if ($matched || strpos($line, 'class') !== FALSE) {
 				break;
 			}
 		}
 		fclose ($fileHandle);
 
-		$matches = NULL;
-		$matched = preg_match('/^namespace[ \t]+(.*);$/', $lines[1], $matches);
-
-		return ($matched ? $matches[1] . '\\' : '');
+		return ($matched && isset($matches) ? $matches[1] . '\\' : '');
 	}
 
 }


### PR DESCRIPTION
The current implementation only checks the first two line. This
patch changes this behaviour to continue to check until the first
occurence of the "namespace" or "class" keyword.
