### PR TITLE
Use ReST format for README instead of Markdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
-# EXT:phpstorm
 
-## Description
+============
+EXT:phpstorm
+============
+
+Description
+===========
 
 PhpStorm 6.0.1 EAP-129.196 introduced support for a meta data file -
 .phpstorm.meta.php - to help its code completion when factory methods are used.
@@ -14,7 +18,8 @@ Supported factory methods are:
 * TYPO3\CMS\Extbase\Object\ObjectManager::create
 * TYPO3\CMS\Extbase\Object\ObjectManager::get
 
-## Usage
+Usage
+=====
 
 The extension provides a cli command to execute the generation of the meta data
 sfile.
@@ -22,26 +27,30 @@ sfile.
 First, add a TYPO3 backend user named "_cli_phpstorm", password doesn't matter
 and it also doesn't need any permissions, just needs to exist.
 
-Now, in your TYPO3 installation's root directory execute the following command:
+Now, in your TYPO3 installation's root directory execute the following command::
 
 	typo3/cli_dispatch.phpsh phpstorm_metadata
 
 Note, this will take some time since all the PHP files in your installation
 will be analyzed.
 
-## Commandline Arguments
+Commandline Arguments
+=====================
 
-### --disableClassAliases
+--disableClassAliases
+---------------------
 
 TYPO3 CMS 6.0 introduced namespaces and cleaned up a lot of class names. To
 provide backwardscompatibility with extensions that do not use the new names
 yet a class alias map has been created. By default that alias map is included.
 Use --disableClassAliases to prevent including those aliasses.
 
-### -s, --silent
+-s, --silent
+------------
 
 Silent operation, will only output errors and important messages.
 
-### -ss
+-ss
+---
 
 Super silent, will not even output errors or important messages.


### PR DESCRIPTION
Github will understand both formats. But documentation will only appear at http://docs.typo3.org/typo3cms/extensions/phpstorm if there is a complete ReST documentation folder or at least the "README.rst" file in the extensions root folder.
